### PR TITLE
Fix multiple time related bugs

### DIFF
--- a/cmd/bovctl/main.go
+++ b/cmd/bovctl/main.go
@@ -47,7 +47,7 @@ func main() {
 	case today:
 		opts.TodayOnly()
 	case tomorrow:
-		opts.TodayOnly()
+		opts.TomorrowOnly()
 	default:
 		// No-Op.
 	}

--- a/response.go
+++ b/response.go
@@ -12,10 +12,15 @@ const (
 
 	upcomingOnlyKey = "preMatchOnly"
 	langKey         = "lang"
-	startTimeKey    = "startTimeLimit"
 
-	startTimeToday    = "410"
-	startTimeTomorrow = "1847"
+	// Bovada uses minutes as their units for their time limiting parameters.
+
+	// startTimeKey represents the time (in minutes from now)
+	// which the event must start prior to.
+	startTimeKey = "startTimeLimit"
+	// startTimeOffsetKey represents the time (in minutes from now)
+	// which the event must start after.
+	startTimeOffsetKey = "startTimeOffset"
 )
 
 // path includes metadata about the returned events.


### PR DESCRIPTION
Two bugs:

1. I incorrectly assumed that the time related parameters were some werid static enums... after a bit of analysis within their UI, I deduced that it is actually time in minutes. I also noticed there was a second time related param to limit start times AFTER it (duh).

2. I just had a typo in bovctl which used TodayOnly instead of the TomorrowOnly when passed `-d tomorrow`