### PR TITLE
Pretty output formatting, limit query to only GAMEEVENTs, etc.

### DIFF
--- a/response.go
+++ b/response.go
@@ -12,6 +12,7 @@ const (
 
 	upcomingOnlyKey = "preMatchOnly"
 	langKey         = "lang"
+	gamesFilterKey  = "marketFilterId"
 
 	// Bovada uses minutes as their units for their time limiting parameters.
 


### PR DESCRIPTION
The main purpose of this change is to pretty the output using the text/tabwriter package. However, there were a number of bugs which have now been fixed.

1. Limiting responses to only GAMEEVENTs. Without an additional query paramter, the results included things like prop bets, which did not have 'Competitors' (and are also not relevant).

2. Catch cases of no results. In the event that no events match the query, don't panic, return a helpful error.