### PR TITLE
Add NFL and CFB as possible inputs

### DIFF
--- a/client.go
+++ b/client.go
@@ -91,6 +91,15 @@ func (q *queryOpts) TomorrowOnly() *queryOpts {
 	return q
 }
 
+// ThisWeek will return all events through the upcoming Sunday, inclusive.
+func (q *queryOpts) ThisWeek() *queryOpts {
+	var t = minutesLeftInWeek(now())
+	q.query.Del(startTimeOffsetKey)
+	q.query.Set(startTimeKey, strconv.Itoa(t))
+
+	return q
+}
+
 // GetEvents queries the API for the given path and with the specified options.
 func (c *Client) GetEvents(path string, opts *queryOpts) (*EventResponse, error) {
 	if opts == nil {
@@ -146,4 +155,14 @@ const minutesInDay = 60 * 24 // 1,440.
 // in the day (rounded down) given time |t|.
 func minutesLeftInDay(t time.Time) int {
 	return (23-t.Hour())*60 + (60 - t.Minute())
+}
+
+// minutesLeftInWeek returns the number of minutes remaining
+// in the week ending on Sunday (rounded down) given time |t|.
+func minutesLeftInWeek(t time.Time) int {
+	if t.Weekday() == 0 {
+		return minutesLeftInDay(t)
+	}
+
+	return (7-int(t.Weekday()))*minutesInDay + minutesLeftInDay(t)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -169,36 +169,42 @@ func (cs *clientSuite) TestGetEvents(c *check.C) {
 
 func (cs *clientSuite) TestMinutesLeftInDay(c *check.C) {
 	var tcs = []struct {
-		name string
-		t    time.Time
-		exp  int
+		name    string
+		t       time.Time
+		expDay  int
+		expWeek int
 	}{
 		{
-			name: "Hours no minutes.",
-			t:    time.Date(2020, time.August, 12, 1, 0, 0, 0, time.UTC),
-			exp:  22*60 + 60,
+			name:    "Hours no minutes, Wednesday.",
+			t:       time.Date(2020, time.August, 12, 1, 0, 0, 0, time.UTC),
+			expDay:  22*60 + 60,
+			expWeek: (22*60 + 60) + (4 * 24 * 60),
 		},
 		{
-			name: "Hours and minutes.",
-			t:    time.Date(2020, time.August, 12, 1, 1, 0, 0, time.UTC),
-			exp:  22*60 + 59,
+			name:    "Hours and minutes, Thursday.",
+			t:       time.Date(2020, time.August, 13, 1, 1, 0, 0, time.UTC),
+			expDay:  22*60 + 59,
+			expWeek: (22*60 + 59) + (3 * 24 * 60),
 		},
 		{
-			name: "Hours, minutes, seconds, nanoseconds.",
-			t:    time.Date(2020, time.August, 12, 1, 1, 1, 1, time.UTC),
-			exp:  22*60 + 59,
+			name:    "Hours, minutes, seconds, nanoseconds, Sunday.",
+			t:       time.Date(2020, time.August, 16, 1, 1, 1, 1, time.UTC),
+			expDay:  22*60 + 59,
+			expWeek: 22*60 + 59,
 		},
 		{
-			name: "Hours, minutes, seconds, nanoseconds (afternoon).",
-			t:    time.Date(2020, time.August, 12, 13, 1, 1, 1, time.UTC),
-			exp:  10*60 + 59,
+			name:    "Hours, minutes, seconds, nanoseconds (afternoon), Monday.",
+			t:       time.Date(2020, time.August, 17, 13, 1, 1, 1, time.UTC),
+			expDay:  10*60 + 59,
+			expWeek: 10*60 + 59 + (6 * 24 * 60),
 		},
 	}
 
 	for _, tc := range tcs {
 		c.Log(tc.name)
 
-		c.Check(minutesLeftInDay(tc.t), check.Equals, tc.exp)
+		c.Check(minutesLeftInDay(tc.t), check.Equals, tc.expDay)
+		c.Check(minutesLeftInWeek(tc.t), check.Equals, tc.expWeek)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -47,6 +47,7 @@ func (cs *clientSuite) TestQueryOpts(c *check.C) {
 	// Compute expected query param values.
 	var sEOD = strconv.Itoa(minutesLeftInDay(d))
 	var sEOT = strconv.Itoa(minutesLeftInDay(d) + minutesInDay)
+	var sEOW = strconv.Itoa(minutesLeftInWeek(d))
 
 	var tcs = []struct {
 		name string
@@ -75,6 +76,14 @@ func (cs *clientSuite) TestQueryOpts(c *check.C) {
 				langKey:            []string{"en"},
 				startTimeKey:       []string{sEOT},
 				startTimeOffsetKey: []string{sEOD},
+			},
+		},
+		{
+			name: "Default opts + this week.",
+			opts: NewQueryOpts().ThisWeek(),
+			exp: url.Values{
+				langKey:      []string{"en"},
+				startTimeKey: []string{sEOW},
 			},
 		},
 		{
@@ -126,6 +135,15 @@ func (cs *clientSuite) TestQueryOpts(c *check.C) {
 				upcomingOnlyKey:    []string{"false"},
 				startTimeKey:       []string{sEOT},
 				startTimeOffsetKey: []string{sEOD},
+			},
+		},
+		{
+			name: "Default opts + upcoming true + today + upcoming false + this week (this week + false should overwrite).",
+			opts: NewQueryOpts().UpcomingOnly(true).TodayOnly().UpcomingOnly(false).ThisWeek(),
+			exp: url.Values{
+				langKey:            []string{"en"},
+				upcomingOnlyKey:    []string{"false"},
+				startTimeKey:       []string{sEOW},
 			},
 		},
 	}

--- a/cmd/bovctl/main.go
+++ b/cmd/bovctl/main.go
@@ -23,7 +23,7 @@ const (
 
 	today    = "today"
 	tomorrow = "tomorrow"
-	week = "week"
+	week     = "week"
 )
 
 var (

--- a/cmd/bovctl/main.go
+++ b/cmd/bovctl/main.go
@@ -18,13 +18,15 @@ const (
 	mlb = "mlb"
 	nba = "nba"
 	nhl = "nhl"
+	nfl = "nfl"
+	cfb = "cfb"
 
 	today    = "today"
 	tomorrow = "tomorrow"
 )
 
 var (
-	league   = flag.String("l", "mlb", `Specify which league to query events for ("mlb", "nba"", "nhl").`)
+	league   = flag.String("l", "mlb", `Specify which league to query events for ("mlb", "nba", "nhl", "nfl", "cfb").`)
 	num      = flag.Int("n", 1, "Number of events to chose a bet for.")
 	date     = flag.String("d", "all", `Limits events to a certain day ("today", "tomorrow", "all"')`)
 	upcoming = flag.Bool("u", false, "Upcoming events only")
@@ -34,6 +36,8 @@ var leagueMap = map[string]string{
 	mlb: bovada.MLBPath,
 	nba: bovada.NBAPath,
 	nhl: bovada.NHLPath,
+	nfl: bovada.NFLPath,
+	cfb: bovada.CFBPath,
 }
 
 func main() {

--- a/cmd/bovctl/main.go
+++ b/cmd/bovctl/main.go
@@ -23,6 +23,7 @@ const (
 
 	today    = "today"
 	tomorrow = "tomorrow"
+	week = "week"
 )
 
 var (
@@ -55,6 +56,8 @@ func main() {
 		opts.TodayOnly()
 	case tomorrow:
 		opts.TomorrowOnly()
+	case week:
+		opts.ThisWeek()
 	default:
 		// No-Op.
 	}

--- a/response.go
+++ b/response.go
@@ -9,6 +9,10 @@ const (
 	NBAPath = "services/sports/event/coupon/events/A/description/basketball/nba"
 	// NHLPath is the path for the NHL events endpoint.
 	NHLPath = "services/sports/event/coupon/events/A/description/hockey/nhl"
+	// NFLPath is the path for the NFL events endpoint.
+	NFLPath = "services/sports/event/coupon/events/A/description/football/nfl"
+	// CFBPath is the path for the NCAA College Football events endpoint.
+	CFBPath = "services/sports/event/coupon/events/A/description/football/college-football"
 
 	upcomingOnlyKey = "preMatchOnly"
 	langKey         = "lang"


### PR DESCRIPTION
Now that football has started, users may want to create parlays with new leagues.